### PR TITLE
fix: clean up stale scroll positions and sessionStorage entries

### DIFF
--- a/.changeset/fix-cleanup-stale-navigation-data.md
+++ b/.changeset/fix-cleanup-stale-navigation-data.md
@@ -1,0 +1,7 @@
+---
+"rehynav": patch
+---
+
+Fix memory leak: clean up stale scroll positions and sessionStorage entries when navigation entries are removed
+
+`useScrollRestoration` now removes scroll positions from its internal Map when components unmount. `HistorySyncManager` now detects removed entries on state changes and removes their sessionStorage params, preventing unbounded storage growth.

--- a/src/hooks/useScrollRestoration.test.tsx
+++ b/src/hooks/useScrollRestoration.test.tsx
@@ -9,7 +9,11 @@ import type { NavigationAction, NavigationState } from '../core/types.js';
 import type { Serializable } from '../types/serializable.js';
 import type { NavigationStoreForHooks } from './context.js';
 import { GuardRegistryContext, NavigationStoreContext, RouteContext } from './context.js';
-import { useScrollRestoration } from './useScrollRestoration.js';
+import {
+  clearAllScrollPositions,
+  removeScrollPosition,
+  useScrollRestoration,
+} from './useScrollRestoration.js';
 
 function createTestStore(initialState: NavigationState): NavigationStoreForHooks {
   let state = initialState;
@@ -136,5 +140,152 @@ describe('useScrollRestoration', () => {
         { wrapper },
       );
     }).not.toThrow();
+  });
+
+  describe('cleanup', () => {
+    it('removes scroll position when component unmounts', () => {
+      const state = createInitialState(
+        { tabs: ['home'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const topEntryId = store.getState().tabs.home.stack[0].id;
+      const wrapper = createWrapper(store, { route: 'home', params: {}, entryId: topEntryId });
+
+      const mockEl = createMockElement(200);
+
+      const { unmount } = renderHook(
+        () => {
+          const ref = useRef<HTMLDivElement>(null);
+          (ref as { current: HTMLDivElement | null }).current = mockEl;
+          useScrollRestoration(ref);
+          return ref;
+        },
+        { wrapper },
+      );
+
+      // Save a scroll position by triggering blur
+      act(() => {
+        store.dispatch({
+          type: 'OPEN_OVERLAY',
+          route: 'dialog',
+          params: {},
+          id: 'overlay-cleanup-1',
+          timestamp: 2000,
+        });
+      });
+
+      // Unmount the component (simulates entry being popped from stack)
+      unmount();
+
+      // Re-mount with the same entryId — scroll position should NOT be restored
+      // because it was cleaned up on unmount
+      const mockEl2 = createMockElement(0);
+      const wrapper2 = createWrapper(store, { route: 'home', params: {}, entryId: topEntryId });
+
+      renderHook(
+        () => {
+          const ref = useRef<HTMLDivElement>(null);
+          (ref as { current: HTMLDivElement | null }).current = mockEl2;
+          useScrollRestoration(ref);
+          return ref;
+        },
+        { wrapper: wrapper2 },
+      );
+
+      // scrollTo should not have been called with the old position
+      expect(mockEl2.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('removeScrollPosition removes a specific entry', () => {
+      clearAllScrollPositions();
+
+      const state = createInitialState(
+        { tabs: ['home'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const topEntryId = store.getState().tabs.home.stack[0].id;
+      const wrapper = createWrapper(store, { route: 'home', params: {}, entryId: topEntryId });
+
+      const mockEl = createMockElement(300);
+
+      renderHook(
+        () => {
+          const ref = useRef<HTMLDivElement>(null);
+          (ref as { current: HTMLDivElement | null }).current = mockEl;
+          useScrollRestoration(ref);
+          return ref;
+        },
+        { wrapper },
+      );
+
+      // Trigger blur to save scroll position
+      act(() => {
+        store.dispatch({
+          type: 'OPEN_OVERLAY',
+          route: 'dialog',
+          params: {},
+          id: 'overlay-remove-1',
+          timestamp: 2000,
+        });
+      });
+
+      // Remove the scroll position externally
+      removeScrollPosition(topEntryId);
+
+      // Close overlay to trigger focus — should NOT restore
+      act(() => {
+        store.dispatch({ type: 'CLOSE_OVERLAY' });
+      });
+
+      expect(mockEl.scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 300 }));
+    });
+
+    it('clearAllScrollPositions removes all entries', () => {
+      const state = createInitialState(
+        { tabs: ['home'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const topEntryId = store.getState().tabs.home.stack[0].id;
+      const wrapper = createWrapper(store, { route: 'home', params: {}, entryId: topEntryId });
+
+      const mockEl = createMockElement(400);
+
+      renderHook(
+        () => {
+          const ref = useRef<HTMLDivElement>(null);
+          (ref as { current: HTMLDivElement | null }).current = mockEl;
+          useScrollRestoration(ref);
+          return ref;
+        },
+        { wrapper },
+      );
+
+      // Trigger blur to save scroll position
+      act(() => {
+        store.dispatch({
+          type: 'OPEN_OVERLAY',
+          route: 'dialog',
+          params: {},
+          id: 'overlay-clear-1',
+          timestamp: 2000,
+        });
+      });
+
+      // Clear all
+      clearAllScrollPositions();
+
+      // Close overlay to trigger focus — should NOT restore
+      act(() => {
+        store.dispatch({ type: 'CLOSE_OVERLAY' });
+      });
+
+      expect(mockEl.scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 400 }));
+    });
   });
 });

--- a/src/hooks/useScrollRestoration.test.tsx
+++ b/src/hooks/useScrollRestoration.test.tsx
@@ -143,16 +143,29 @@ describe('useScrollRestoration', () => {
   });
 
   describe('cleanup', () => {
-    it('removes scroll position when component unmounts', () => {
+    it('removes scroll position when entry is popped from state', () => {
+      clearAllScrollPositions();
+
       const state = createInitialState(
         { tabs: ['home'], initialTab: 'home' },
         testCreateId,
         () => 1000,
       );
       const store = createTestStore(state);
-      const topEntryId = store.getState().tabs.home.stack[0].id;
-      const wrapper = createWrapper(store, { route: 'home', params: {}, entryId: topEntryId });
 
+      // Push a second entry onto the stack
+      const pushedId = testCreateId();
+      act(() => {
+        store.dispatch({
+          type: 'PUSH',
+          route: 'home/detail',
+          params: {},
+          id: pushedId,
+          timestamp: 2000,
+        });
+      });
+
+      const wrapper = createWrapper(store, { route: 'home/detail', params: {}, entryId: pushedId });
       const mockEl = createMockElement(200);
 
       const { unmount } = renderHook(
@@ -172,17 +185,25 @@ describe('useScrollRestoration', () => {
           route: 'dialog',
           params: {},
           id: 'overlay-cleanup-1',
-          timestamp: 2000,
+          timestamp: 3000,
         });
       });
 
-      // Unmount the component (simulates entry being popped from stack)
+      // Pop the entry from state (removes pushedId), then unmount
+      act(() => {
+        store.dispatch({ type: 'CLOSE_OVERLAY' });
+        store.dispatch({ type: 'POP' });
+      });
       unmount();
 
       // Re-mount with the same entryId — scroll position should NOT be restored
-      // because it was cleaned up on unmount
+      // because it was cleaned up on unmount after entry was removed from state
       const mockEl2 = createMockElement(0);
-      const wrapper2 = createWrapper(store, { route: 'home', params: {}, entryId: topEntryId });
+      const wrapper2 = createWrapper(store, {
+        route: 'home/detail',
+        params: {},
+        entryId: pushedId,
+      });
 
       renderHook(
         () => {
@@ -196,6 +217,66 @@ describe('useScrollRestoration', () => {
 
       // scrollTo should not have been called with the old position
       expect(mockEl2.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('preserves scroll position when component unmounts but entry still in state (tab switch)', () => {
+      clearAllScrollPositions();
+
+      const state = createInitialState(
+        { tabs: ['home', 'search'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const homeEntryId = store.getState().tabs.home.stack[0].id;
+      const wrapper = createWrapper(store, { route: 'home', params: {}, entryId: homeEntryId });
+
+      const mockEl = createMockElement(250);
+
+      const { unmount } = renderHook(
+        () => {
+          const ref = useRef<HTMLDivElement>(null);
+          (ref as { current: HTMLDivElement | null }).current = mockEl;
+          useScrollRestoration(ref);
+          return ref;
+        },
+        { wrapper },
+      );
+
+      // Trigger blur to save scroll position
+      act(() => {
+        store.dispatch({
+          type: 'OPEN_OVERLAY',
+          route: 'dialog',
+          params: {},
+          id: 'overlay-tab-1',
+          timestamp: 2000,
+        });
+      });
+
+      // Close overlay and switch tabs — entry stays in state but component unmounts
+      // (simulates preserveState=false tab behavior)
+      act(() => {
+        store.dispatch({ type: 'CLOSE_OVERLAY' });
+      });
+      unmount();
+
+      // Re-mount (simulates switching back to the tab)
+      const mockEl2 = createMockElement(0);
+      const wrapper2 = createWrapper(store, { route: 'home', params: {}, entryId: homeEntryId });
+
+      renderHook(
+        () => {
+          const ref = useRef<HTMLDivElement>(null);
+          (ref as { current: HTMLDivElement | null }).current = mockEl2;
+          useScrollRestoration(ref);
+          return ref;
+        },
+        { wrapper: wrapper2 },
+      );
+
+      // Scroll position SHOULD be restored because entry still exists in state
+      expect(mockEl2.scrollTo).toHaveBeenCalledWith({ top: 250, behavior: 'instant' });
     });
 
     it('removeScrollPosition removes a specific entry', () => {

--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -1,8 +1,16 @@
-import { type RefObject, useContext, useRef } from 'react';
+import { type RefObject, useContext, useEffect, useRef } from 'react';
 import { RouteContext } from './context.js';
 import { useFocusEffect } from './useFocusEffect.js';
 
 const scrollPositions = new Map<string, number>();
+
+export function removeScrollPosition(entryId: string): void {
+  scrollPositions.delete(entryId);
+}
+
+export function clearAllScrollPositions(): void {
+  scrollPositions.clear();
+}
 
 export function useScrollRestoration(ref: RefObject<HTMLElement | null>): void {
   const routeCtx = useContext(RouteContext);
@@ -28,4 +36,14 @@ export function useScrollRestoration(ref: RefObject<HTMLElement | null>): void {
       }
     };
   });
+
+  // Clean up scroll position when component unmounts (entry removed from state)
+  useEffect(() => {
+    const id = entryId;
+    return () => {
+      if (id) {
+        scrollPositions.delete(id);
+      }
+    };
+  }, [entryId]);
 }

--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -1,5 +1,6 @@
 import { type RefObject, useContext, useEffect, useRef } from 'react';
-import { RouteContext } from './context.js';
+import type { NavigationState } from '../core/types.js';
+import { NavigationStoreContext, RouteContext } from './context.js';
 import { useFocusEffect } from './useFocusEffect.js';
 
 const scrollPositions = new Map<string, number>();
@@ -12,8 +13,24 @@ export function clearAllScrollPositions(): void {
   scrollPositions.clear();
 }
 
+function entryExistsInState(state: NavigationState, entryId: string): boolean {
+  for (const tabState of Object.values(state.tabs)) {
+    for (const entry of tabState.stack) {
+      if (entry.id === entryId) return true;
+    }
+  }
+  for (const entry of state.screens) {
+    if (entry.id === entryId) return true;
+  }
+  for (const entry of state.overlays) {
+    if (entry.id === entryId) return true;
+  }
+  return false;
+}
+
 export function useScrollRestoration(ref: RefObject<HTMLElement | null>): void {
   const routeCtx = useContext(RouteContext);
+  const store = useContext(NavigationStoreContext);
   const entryId = routeCtx?.entryId ?? null;
   const entryIdRef = useRef(entryId);
   entryIdRef.current = entryId;
@@ -37,13 +54,16 @@ export function useScrollRestoration(ref: RefObject<HTMLElement | null>): void {
     };
   });
 
-  // Clean up scroll position when component unmounts (entry removed from state)
+  // Clean up scroll position when component unmounts, but only if the
+  // entry was actually removed from navigation state. This prevents
+  // false cleanup when tab switching with preserveState=false unmounts
+  // components whose entries still exist in state.
   useEffect(() => {
     const id = entryId;
     return () => {
-      if (id) {
+      if (id && store && !entryExistsInState(store.getState(), id)) {
         scrollPositions.delete(id);
       }
     };
-  }, [entryId]);
+  }, [entryId, store]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,11 @@ export type { OverlayActions } from './hooks/useOverlay.js';
 export { useOverlay } from './hooks/useOverlay.js';
 export type { RouteInfoResult } from './hooks/useRoute.js';
 export { useRoute } from './hooks/useRoute.js';
-export { useScrollRestoration } from './hooks/useScrollRestoration.js';
+export {
+  clearAllScrollPositions,
+  removeScrollPosition,
+  useScrollRestoration,
+} from './hooks/useScrollRestoration.js';
 export type { TabActions } from './hooks/useTab.js';
 export { useTab } from './hooks/useTab.js';
 

--- a/src/sync/history-sync.test.ts
+++ b/src/sync/history-sync.test.ts
@@ -389,6 +389,18 @@ describe('HistorySyncManager', () => {
         sessionStorage.setItem = originalSetItem;
       }
     });
+
+    it('should not throw when removeParams encounters sessionStorage failure', () => {
+      const originalRemoveItem = sessionStorage.removeItem.bind(sessionStorage);
+      sessionStorage.removeItem = () => {
+        throw new Error('SecurityError');
+      };
+      try {
+        expect(() => manager.removeParams('entry-1')).not.toThrow();
+      } finally {
+        sessionStorage.removeItem = originalRemoveItem;
+      }
+    });
   });
 
   describe('sessionStorage cleanup on entry removal', () => {
@@ -482,6 +494,53 @@ describe('HistorySyncManager', () => {
 
       // Root entry params should still exist
       expect(sessionStorage.getItem(`rehynav:${rootEntryId}`)).not.toBeNull();
+    });
+
+    it('should clean up sessionStorage when handlePopState triggers RESET_STATE', () => {
+      manager = new HistorySyncManager(store, '/', undefined, defaultSyncConfig);
+
+      Object.defineProperty(window, 'location', {
+        value: { pathname: '/search', search: '' },
+        writable: true,
+        configurable: true,
+      });
+
+      manager.start();
+
+      // Push entries and persist their params
+      const id1 = createId();
+      const id2 = createId();
+      store.dispatch({
+        type: 'PUSH',
+        route: 'home/detail',
+        params: { x: '1' },
+        id: id1,
+        timestamp: Date.now(),
+      });
+      store.dispatch({
+        type: 'PUSH',
+        route: 'home/settings',
+        params: { y: '2' },
+        id: id2,
+        timestamp: Date.now(),
+      });
+
+      expect(sessionStorage.getItem(`rehynav:${id1}`)).not.toBeNull();
+      expect(sessionStorage.getItem(`rehynav:${id2}`)).not.toBeNull();
+
+      // Simulate browser forward to a non-existent entry → triggers RESET_STATE
+      const event = new PopStateEvent('popstate', {
+        state: {
+          entryId: 'deleted-entry-id',
+          activeTab: 'search',
+          tabStacks: { home: ['home'], search: ['search'], profile: ['profile'] },
+        },
+      });
+      window.dispatchEvent(event);
+
+      // Old entries from before RESET_STATE should be cleaned up
+      expect(sessionStorage.getItem(`rehynav:${id1}`)).toBeNull();
+      expect(sessionStorage.getItem(`rehynav:${id2}`)).toBeNull();
     });
   });
 

--- a/src/sync/history-sync.test.ts
+++ b/src/sync/history-sync.test.ts
@@ -369,6 +369,14 @@ describe('HistorySyncManager', () => {
       expect(stored).toBe(JSON.stringify({ foo: 'bar' }));
     });
 
+    it('should remove params from sessionStorage via removeParams', () => {
+      manager.persistParams('entry-1', { foo: 'bar' });
+      expect(sessionStorage.getItem('rehynav:entry-1')).not.toBeNull();
+
+      manager.removeParams('entry-1');
+      expect(sessionStorage.getItem('rehynav:entry-1')).toBeNull();
+    });
+
     it('should not throw when sessionStorage fails', () => {
       // Override sessionStorage with a throwing implementation
       const originalSetItem = sessionStorage.setItem.bind(sessionStorage);
@@ -380,6 +388,100 @@ describe('HistorySyncManager', () => {
       } finally {
         sessionStorage.setItem = originalSetItem;
       }
+    });
+  });
+
+  describe('sessionStorage cleanup on entry removal', () => {
+    it('should remove sessionStorage entry when stack entry is popped', () => {
+      manager.start();
+
+      // Push to create a second entry
+      const pushedId = createId();
+      store.dispatch({
+        type: 'PUSH',
+        route: 'home/detail',
+        params: { id: '42' },
+        id: pushedId,
+        timestamp: Date.now(),
+      });
+
+      // Verify params were persisted
+      expect(sessionStorage.getItem(`rehynav:${pushedId}`)).not.toBeNull();
+
+      // Pop the entry
+      store.dispatch({ type: 'POP' });
+
+      // sessionStorage entry should be cleaned up
+      expect(sessionStorage.getItem(`rehynav:${pushedId}`)).toBeNull();
+    });
+
+    it('should remove sessionStorage entry when overlay is closed', () => {
+      manager.start();
+
+      const overlayId = createId();
+      store.dispatch({
+        type: 'OPEN_OVERLAY',
+        route: 'dialog',
+        params: { message: 'hello' },
+        id: overlayId,
+        timestamp: Date.now(),
+      });
+
+      expect(sessionStorage.getItem(`rehynav:${overlayId}`)).not.toBeNull();
+
+      store.dispatch({ type: 'CLOSE_OVERLAY' });
+
+      expect(sessionStorage.getItem(`rehynav:${overlayId}`)).toBeNull();
+    });
+
+    it('should remove sessionStorage entries when POP_TO_ROOT removes multiple entries', () => {
+      manager.start();
+
+      const id1 = createId();
+      const id2 = createId();
+      store.dispatch({
+        type: 'PUSH',
+        route: 'home/detail',
+        params: {},
+        id: id1,
+        timestamp: Date.now(),
+      });
+      store.dispatch({
+        type: 'PUSH',
+        route: 'home/settings',
+        params: {},
+        id: id2,
+        timestamp: Date.now(),
+      });
+
+      expect(sessionStorage.getItem(`rehynav:${id1}`)).not.toBeNull();
+      expect(sessionStorage.getItem(`rehynav:${id2}`)).not.toBeNull();
+
+      store.dispatch({ type: 'POP_TO_ROOT' });
+
+      expect(sessionStorage.getItem(`rehynav:${id1}`)).toBeNull();
+      expect(sessionStorage.getItem(`rehynav:${id2}`)).toBeNull();
+    });
+
+    it('should not remove sessionStorage entries for entries still in state', () => {
+      manager.start();
+
+      const rootEntryId = store.getState().tabs.home.stack[0].id;
+
+      const pushedId = createId();
+      store.dispatch({
+        type: 'PUSH',
+        route: 'home/detail',
+        params: {},
+        id: pushedId,
+        timestamp: Date.now(),
+      });
+
+      // Pop: removes pushedId but root remains
+      store.dispatch({ type: 'POP' });
+
+      // Root entry params should still exist
+      expect(sessionStorage.getItem(`rehynav:${rootEntryId}`)).not.toBeNull();
     });
   });
 

--- a/src/sync/history-sync.ts
+++ b/src/sync/history-sync.ts
@@ -123,11 +123,39 @@ export class HistorySyncManager {
     }
   }
 
+  private collectEntryIds(state: NavigationState): Set<string> {
+    const ids = new Set<string>();
+    for (const tabState of Object.values(state.tabs)) {
+      for (const entry of tabState.stack) {
+        ids.add(entry.id);
+      }
+    }
+    for (const entry of state.screens) {
+      ids.add(entry.id);
+    }
+    for (const entry of state.overlays) {
+      ids.add(entry.id);
+    }
+    return ids;
+  }
+
+  private cleanupRemovedEntries(prev: NavigationState, current: NavigationState): void {
+    const prevIds = this.collectEntryIds(prev);
+    const currentIds = this.collectEntryIds(current);
+    for (const id of prevIds) {
+      if (!currentIds.has(id)) {
+        this.removeParams(id);
+      }
+    }
+  }
+
   private syncHistoryFromStateChange(): void {
     const currentState = this.store.getState();
     const prev = this.previousState;
 
     if (!prev) return;
+
+    this.cleanupRemovedEntries(prev, currentState);
 
     const url = stateToUrl(currentState, this.basePath, this.routePatterns);
     const historyState = this.createHistoryState(currentState);
@@ -275,6 +303,14 @@ export class HistorySyncManager {
       sessionStorage.setItem(key, JSON.stringify(params));
     } catch {
       // sessionStorage may be unavailable or full; silently ignore
+    }
+  }
+
+  removeParams(entryId: string): void {
+    try {
+      sessionStorage.removeItem(`rehynav:${entryId}`);
+    } catch {
+      // sessionStorage may be unavailable; silently ignore
     }
   }
 

--- a/src/sync/history-sync.ts
+++ b/src/sync/history-sync.ts
@@ -93,6 +93,7 @@ export class HistorySyncManager {
 
     this.isSyncing = true;
     try {
+      const prevState = this.previousState;
       this.store.dispatch({ type: 'RESTORE_TO_ENTRY', entryId: historyState.entryId });
 
       // Check if restoration succeeded by verifying the top entry matches
@@ -117,7 +118,14 @@ export class HistorySyncManager {
         window.history.replaceState(updatedHistoryState, '', undefined);
       }
 
-      this.previousState = this.store.getState();
+      // Clean up sessionStorage for entries removed during popstate handling.
+      // syncHistoryFromStateChange is skipped (isSyncing=true), so cleanup here.
+      const currentState = this.store.getState();
+      if (prevState) {
+        this.cleanupRemovedEntries(prevState, currentState);
+      }
+
+      this.previousState = currentState;
     } finally {
       this.isSyncing = false;
     }
@@ -306,6 +314,7 @@ export class HistorySyncManager {
     }
   }
 
+  /** Remove persisted params from sessionStorage for a given entry. */
   removeParams(entryId: string): void {
     try {
       sessionStorage.removeItem(`rehynav:${entryId}`);


### PR DESCRIPTION
## Summary

- `useScrollRestoration`: Added `useEffect` cleanup to remove scroll positions from the module-level Map when components unmount (entry popped). Exported `removeScrollPosition` and `clearAllScrollPositions` helpers for external cleanup.
- `HistorySyncManager`: Added `removeParams` method and automatic cleanup in `syncHistoryFromStateChange` that compares previous/current state entry IDs and removes sessionStorage entries for removed entries.

Fixes #9

## Related Issues

Fixes #9

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build

## Checklist

- [x] Tests added or updated
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes