### PR TITLE
feat: support resolved path navigation

### DIFF
--- a/.changeset/support-resolved-path-navigation.md
+++ b/.changeset/support-resolved-path-navigation.md
@@ -1,0 +1,5 @@
+---
+"rehynav": minor
+---
+
+Support resolved path navigation: `push('/home/detail/42')` instead of `push('home/detail/:id', { id: '42' })`. The existing route pattern + params API remains fully supported.

--- a/src/hooks/useNavigation.test.tsx
+++ b/src/hooks/useNavigation.test.tsx
@@ -5,11 +5,12 @@ import {
   createNavigationGuardRegistry,
   type NavigationGuardRegistry,
 } from '../core/navigation-guard.js';
+import { parseRoutePatterns, type RoutePattern } from '../core/path-params.js';
 import { navigationReducer } from '../core/reducer.js';
 import { createInitialState } from '../core/state.js';
 import type { NavigationAction, NavigationState } from '../core/types.js';
 import type { NavigationStoreForHooks } from './context.js';
-import { GuardRegistryContext, NavigationStoreContext } from './context.js';
+import { GuardRegistryContext, NavigationStoreContext, RoutePatternsContext } from './context.js';
 import { useNavigation } from './useNavigation.js';
 
 function createTestStore(initialState: NavigationState): NavigationStoreForHooks {
@@ -41,12 +42,19 @@ function testCreateId(): string {
   return `test-id-${++idCounter}`;
 }
 
-function createWrapper(store: NavigationStoreForHooks, guardRegistry?: NavigationGuardRegistry) {
+function createWrapper(
+  store: NavigationStoreForHooks,
+  guardRegistry?: NavigationGuardRegistry,
+  routePatterns?: Map<string, RoutePattern> | null,
+) {
   const registry = guardRegistry ?? createNavigationGuardRegistry();
+  const patterns = routePatterns ?? null;
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
       <NavigationStoreContext.Provider value={store}>
-        <GuardRegistryContext.Provider value={registry}>{children}</GuardRegistryContext.Provider>
+        <GuardRegistryContext.Provider value={registry}>
+          <RoutePatternsContext.Provider value={patterns}>{children}</RoutePatternsContext.Provider>
+        </GuardRegistryContext.Provider>
       </NavigationStoreContext.Provider>
     );
   };
@@ -662,6 +670,168 @@ describe('useNavigation', () => {
       });
 
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Non-serializable value'));
+    });
+  });
+
+  describe('resolved path navigation', () => {
+    const routePatterns = parseRoutePatterns([
+      'home',
+      'home/detail/:id',
+      'search',
+      'search/results/:query',
+      'profile',
+    ]);
+
+    it('push with resolved path extracts route and params', () => {
+      const state = createInitialState(
+        { tabs: ['home', 'search', 'profile'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const wrapper = createWrapper(store, undefined, routePatterns);
+
+      const { result } = renderHook(() => useNavigation(), { wrapper });
+
+      act(() => {
+        result.current.push('/home/detail/42');
+      });
+
+      const newState = store.getState();
+      expect(newState.tabs.home.stack).toHaveLength(2);
+      expect(newState.tabs.home.stack[1].route).toBe('home/detail/:id');
+      expect(newState.tabs.home.stack[1].params).toEqual({ id: '42' });
+    });
+
+    it('replace with resolved path extracts route and params', () => {
+      const state = createInitialState(
+        { tabs: ['home', 'search', 'profile'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const wrapper = createWrapper(store, undefined, routePatterns);
+
+      const { result } = renderHook(() => useNavigation(), { wrapper });
+
+      act(() => {
+        result.current.replace('/home/detail/99');
+      });
+
+      const newState = store.getState();
+      expect(newState.tabs.home.stack).toHaveLength(1);
+      expect(newState.tabs.home.stack[0].route).toBe('home/detail/:id');
+      expect(newState.tabs.home.stack[0].params).toEqual({ id: '99' });
+    });
+
+    it('push with resolved path to non-parameterized route works', () => {
+      const state = createInitialState(
+        { tabs: ['home', 'search', 'profile'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const wrapper = createWrapper(store, undefined, routePatterns);
+
+      const { result } = renderHook(() => useNavigation(), { wrapper });
+
+      act(() => {
+        result.current.push('/search');
+      });
+
+      const newState = store.getState();
+      expect(newState.activeTab).toBe('search');
+      expect(newState.tabs.search.stack).toHaveLength(2);
+      expect(newState.tabs.search.stack[1].route).toBe('search');
+      expect(newState.tabs.search.stack[1].params).toEqual({});
+    });
+
+    it('push with unmatched resolved path warns and does nothing', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const state = createInitialState(
+        { tabs: ['home', 'search', 'profile'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const wrapper = createWrapper(store, undefined, routePatterns);
+
+      const { result } = renderHook(() => useNavigation(), { wrapper });
+
+      act(() => {
+        result.current.push('/unknown/route');
+      });
+
+      expect(store.getState().tabs.home.stack).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No route pattern matched'));
+      warnSpy.mockRestore();
+    });
+
+    it('push with resolved path without routePatterns context warns', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const state = createInitialState(
+        { tabs: ['home', 'search', 'profile'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const wrapper = createWrapper(store, undefined, null);
+
+      const { result } = renderHook(() => useNavigation(), { wrapper });
+
+      act(() => {
+        result.current.push('/home/detail/42');
+      });
+
+      expect(store.getState().tabs.home.stack).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('route patterns are not available'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('navigateToScreen with resolved path extracts route and params', () => {
+      const screenPatterns = parseRoutePatterns(['login', 'login/verify/:code']);
+      const state = createInitialState(
+        { tabs: ['home', 'search'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const wrapper = createWrapper(store, undefined, screenPatterns);
+
+      const { result } = renderHook(() => useNavigation(), { wrapper });
+
+      act(() => {
+        result.current.navigateToScreen('/login/verify/abc123');
+      });
+
+      const newState = store.getState();
+      expect(newState.activeLayer).toBe('screens');
+      expect(newState.screens).toHaveLength(1);
+      expect(newState.screens[0].route).toBe('login/verify/:code');
+      expect(newState.screens[0].params).toEqual({ code: 'abc123' });
+    });
+
+    it('push with route pattern name still works when routePatterns provided', () => {
+      const state = createInitialState(
+        { tabs: ['home', 'search', 'profile'], initialTab: 'home' },
+        testCreateId,
+        () => 1000,
+      );
+      const store = createTestStore(state);
+      const wrapper = createWrapper(store, undefined, routePatterns);
+
+      const { result } = renderHook(() => useNavigation(), { wrapper });
+
+      act(() => {
+        result.current.push('home/detail/:id', { id: '42' });
+      });
+
+      const newState = store.getState();
+      expect(newState.tabs.home.stack).toHaveLength(2);
+      expect(newState.tabs.home.stack[1].route).toBe('home/detail/:id');
+      expect(newState.tabs.home.stack[1].params).toEqual({ id: '42' });
     });
   });
 });

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -1,10 +1,11 @@
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import { useOptionalPreloadContext } from '../components/PreloadContext.js';
 import { createId } from '../core/id.js';
+import { matchUrl } from '../core/path-params.js';
 import { getCurrentRouteInfo } from '../core/route-utils.js';
 import type { RouteInfo, Serializable } from '../core/types.js';
 import { validateSerializable } from '../core/validation.js';
-import { useGuardRegistry, useNavigationStore } from './context.js';
+import { RoutePatternsContext, useGuardRegistry, useNavigationStore } from './context.js';
 
 export interface NavigationActions {
   push(to: string, params?: Record<string, Serializable>): void;
@@ -22,29 +23,67 @@ export function useNavigation(): NavigationActions {
   const store = useNavigationStore();
   const guardRegistry = useGuardRegistry();
   const preloadCtx = useOptionalPreloadContext();
+  const routePatterns = useContext(RoutePatternsContext);
 
-  return useMemo(
-    () => ({
+  return useMemo(() => {
+    function resolvePath(
+      to: string,
+      params: Record<string, Serializable>,
+    ): { route: string; params: Record<string, Serializable> } | null {
+      if (!to.startsWith('/')) {
+        return { route: to, params };
+      }
+
+      if (!routePatterns) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(
+            `[rehynav] Resolved path "${to}" was used, but route patterns are not available. ` +
+              'Wrap your app with RouterProvider to enable path-based navigation.',
+          );
+        }
+        return null;
+      }
+
+      const pathname = to.slice(1); // strip leading '/'
+      const matched = matchUrl(pathname, routePatterns);
+      if (!matched) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(
+            `[rehynav] No route pattern matched the path "${to}". ` +
+              'Check that the path matches a registered route.',
+          );
+        }
+        return null;
+      }
+
+      return { route: matched.route, params: matched.params };
+    }
+
+    return {
       push(to: string, params: Record<string, Serializable> = {}) {
-        validateSerializable(params as Record<string, unknown>, `push("${to}")`);
+        const resolved = resolvePath(to, params);
+        if (!resolved) return;
+        const { route, params: resolvedParams } = resolved;
+
+        validateSerializable(resolvedParams as Record<string, unknown>, `push("${to}")`);
         const state = store.getState();
         const from = getCurrentRouteInfo(state);
-        const toInfo: RouteInfo = { route: to, params };
+        const toInfo: RouteInfo = { route, params: resolvedParams };
         if (!guardRegistry.check(from, toInfo, 'push')) return;
 
         if (state.activeLayer === 'screens') {
           store.dispatch({
             type: 'PUSH_SCREEN',
-            route: to,
-            params,
+            route,
+            params: resolvedParams,
             id: createId(),
             timestamp: Date.now(),
           });
         } else {
           store.dispatch({
             type: 'PUSH',
-            route: to,
-            params,
+            route,
+            params: resolvedParams,
             id: createId(),
             timestamp: Date.now(),
           });
@@ -90,25 +129,29 @@ export function useNavigation(): NavigationActions {
         }
       },
       replace(to: string, params: Record<string, Serializable> = {}) {
-        validateSerializable(params as Record<string, unknown>, `replace("${to}")`);
+        const resolved = resolvePath(to, params);
+        if (!resolved) return;
+        const { route, params: resolvedParams } = resolved;
+
+        validateSerializable(resolvedParams as Record<string, unknown>, `replace("${to}")`);
         const state = store.getState();
         const from = getCurrentRouteInfo(state);
-        const toInfo: RouteInfo = { route: to, params };
+        const toInfo: RouteInfo = { route, params: resolvedParams };
         if (!guardRegistry.check(from, toInfo, 'replace')) return;
 
         if (state.activeLayer === 'screens') {
           store.dispatch({
             type: 'REPLACE_SCREEN',
-            route: to,
-            params,
+            route,
+            params: resolvedParams,
             id: createId(),
             timestamp: Date.now(),
           });
         } else {
           store.dispatch({
             type: 'REPLACE',
-            route: to,
-            params,
+            route,
+            params: resolvedParams,
             id: createId(),
             timestamp: Date.now(),
           });
@@ -152,8 +195,12 @@ export function useNavigation(): NavigationActions {
         return state.tabs[state.activeTab].stack.length > 1;
       },
       preload(to: string, params: Record<string, Serializable> = {}) {
-        validateSerializable(params as Record<string, unknown>, `preload("${to}")`);
-        preloadCtx?.preload(to, params);
+        const resolved = resolvePath(to, params);
+        if (!resolved) return;
+        const { route, params: resolvedParams } = resolved;
+
+        validateSerializable(resolvedParams as Record<string, unknown>, `preload("${to}")`);
+        preloadCtx?.preload(route, resolvedParams);
       },
       navigateToTabs(tab?: string) {
         const from = getCurrentRouteInfo(store.getState());
@@ -163,19 +210,25 @@ export function useNavigation(): NavigationActions {
         store.dispatch({ type: 'NAVIGATE_TO_TABS', tab });
       },
       navigateToScreen(route: string, params: Record<string, Serializable> = {}) {
-        validateSerializable(params as Record<string, unknown>, `navigateToScreen("${route}")`);
+        const resolved = resolvePath(route, params);
+        if (!resolved) return;
+        const { route: resolvedRoute, params: resolvedParams } = resolved;
+
+        validateSerializable(
+          resolvedParams as Record<string, unknown>,
+          `navigateToScreen("${route}")`,
+        );
         const from = getCurrentRouteInfo(store.getState());
-        const toInfo: RouteInfo = { route, params };
+        const toInfo: RouteInfo = { route: resolvedRoute, params: resolvedParams };
         if (!guardRegistry.check(from, toInfo, 'push')) return;
         store.dispatch({
           type: 'NAVIGATE_TO_SCREEN',
-          route,
-          params,
+          route: resolvedRoute,
+          params: resolvedParams,
           id: createId(),
           timestamp: Date.now(),
         });
       },
-    }),
-    [store, guardRegistry, preloadCtx],
-  );
+    };
+  }, [store, guardRegistry, preloadCtx, routePatterns]);
 }


### PR DESCRIPTION
## Summary

- Allow navigation using resolved paths (e.g., `push('/home/detail/42')`) instead of requiring route pattern + params (`push('home/detail/:id', { id: '42' })`)
- Uses existing `matchUrl()` from `path-params.ts` to reverse-match paths against registered route patterns and extract params automatically
- Supports `push`, `replace`, `preload`, and `navigateToScreen` — backward compatible with existing pattern + params API

## Related Issues

Fixes #34

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI / Build

## Checklist

- [x] Tests added or updated
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes